### PR TITLE
[EI-3347] Add support for binary download

### DIFF
--- a/README.sdk.md
+++ b/README.sdk.md
@@ -112,7 +112,7 @@ client = NyxClient()
 subscribed_data = client.get_subscribed_data()
 for data in subscribed_data:
   print(f"Downloading data {data.name}")
-  content = data.download()
+  content = data.as_string() # Note if binary file use as_bytes to get content as bytes
 ```
 
 ## 👉 Gotchas

--- a/examples/advanced/evaluate/evaluate.py
+++ b/examples/advanced/evaluate/evaluate.py
@@ -45,7 +45,7 @@ class Evaluator:
         self.data = client_openai_sm.get_subscribed_data()
         doc_str = ""
         for d in self.data:
-            contents = d.download()
+            contents = d.as_string()
             if contents:
                 doc_str += f"\n\n{d.name}: \n\n {contents}"
 

--- a/nyx_client/data.py
+++ b/nyx_client/data.py
@@ -15,6 +15,7 @@
 """Module that manages individual Nyx Data."""
 
 import logging
+import warnings
 
 import requests
 
@@ -152,11 +153,17 @@ class Data:
             )
 
     def download(self) -> str | None:
-        """DEPRICATED: Download the content of the data as as string.
+        """Download the content of the data as a string.
 
         This method attempts to download the content from the data's URL.
 
         Returns:
-            The downloaded content as string or None, if the download fails.
+            The downloaded content as a string or None, if the download fails.
+
+        .. deprecated:: 0.2.0
+            Use `as_string()` or `as_bytes()` instead.
         """
+        warnings.warn(
+            "Will be removed in 0.2.0 Use as_string() or as bytes() instead", DeprecationWarning, stacklevel=0
+        )
         return self.as_string()

--- a/nyx_client/data.py
+++ b/nyx_client/data.py
@@ -111,29 +111,52 @@ class Data:
     def __str__(self):
         return f"Data({self._title}, {self.url}, {self._content_type})"
 
-    def download(self) -> str | None:
-        """Download the content of the data and populate the class content field.
+    def as_string(self) -> str | None:
+        """Download the content of the data as as string.
 
-        This method attempts to download the content from the data's URL
-        and stores it in the `content` attribute.
+        This method attempts to download the content from the data's URL.
 
         Returns:
             The downloaded content as decoded text or None, if the download fails.
-
-        Note:
-            If the content has already been downloaded, this method returns the cached content without re-downloading.
         """
-        if not self._content:
-            try:
-                rsp = requests.get(self.url)
-                rsp.raise_for_status()
-                self._content = rsp.text
-            except requests.RequestException as ex:
-                log.warning(
-                    "Failed to download content of data [%s], "
-                    "confirm the source is still available with the data producer: %s",
-                    self._title,
-                    ex,
-                )
+        try:
+            rsp = requests.get(self.url)
+            rsp.raise_for_status()
+            return rsp.text
+        except requests.RequestException as ex:
+            log.warning(
+                "Failed to download content of data [%s], "
+                "confirm the source is still available with the data producer: %s",
+                self._title,
+                ex,
+            )
 
-        return self._content
+    def as_bytes(self) -> bytes | None:
+        """Download the content of the data as as bytes.
+
+        This method attempts to download the content from the data's URL.
+
+        Returns:
+            The downloaded content as bytes or None, if the download fails.
+        """
+        try:
+            rsp = requests.get(self.url)
+            rsp.raise_for_status()
+            return rsp.content
+        except requests.RequestException as ex:
+            log.warning(
+                "Failed to download content of data [%s], "
+                "confirm the source is still available with the data producer: %s",
+                self._title,
+                ex,
+            )
+
+    def download(self) -> str | None:
+        """DEPRICATED: Download the content of the data as as string.
+
+        This method attempts to download the content from the data's URL.
+
+        Returns:
+            The downloaded content as string or None, if the download fails.
+        """
+        return self.as_string()

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -60,7 +60,7 @@ def test_data_download(requests_mock, mock_data_details):
 
     requests_mock.get(data.url, text="Test Content")
 
-    content = data.download()
+    content = data.as_string()
     assert content == "Test Content"
     assert data._content == "Test Content"
 
@@ -70,7 +70,7 @@ def test_data_download_cached(mocker, mock_data_details):
 
     data = Data(**mock_data_details)
     data._content = "Cached Content"
-    content = data.download()
+    content = data.as_string()
     assert content == "Cached Content"
     mock_urlopen.assert_not_called()
 
@@ -80,6 +80,6 @@ def test_nyx_data_download_failure(requests_mock, mock_data_details):
 
     requests_mock.get(data.url, exc=requests.exceptions.ConnectTimeout)
 
-    content = data.download()
+    content = data.as_string()
     assert content is None
     assert data._content is None

--- a/test/test_data.py
+++ b/test/test_data.py
@@ -62,17 +62,6 @@ def test_data_download(requests_mock, mock_data_details):
 
     content = data.as_string()
     assert content == "Test Content"
-    assert data._content == "Test Content"
-
-
-def test_data_download_cached(mocker, mock_data_details):
-    mock_urlopen = mocker.patch("urllib.request.urlopen")
-
-    data = Data(**mock_data_details)
-    data._content = "Cached Content"
-    content = data.as_string()
-    assert content == "Cached Content"
-    mock_urlopen.assert_not_called()
 
 
 def test_nyx_data_download_failure(requests_mock, mock_data_details):

--- a/test/test_utils.py
+++ b/test/test_utils.py
@@ -10,40 +10,44 @@ from nyx_client.utils import Metadata, Parser, VectorResult
 
 @pytest.fixture
 def sample_csv_content():
-    return """
+    return bytes(
+        """
     id,name,value
     1,Alice,100
     2,Bob,200
     3,Charlie,300
-    """
+    """,
+        encoding="utf-8",
+    )
 
 
 @pytest.fixture
 def sample_csv_content_2():
-    return """
+    return bytes(
+        """
     id,name,value
     1,Andy,1000
     2,Conal,10
     3,Phil,300
-    """
+    """,
+        encoding="utf-8",
+    )
 
 
 @pytest.fixture
-def sample_data(sample_csv_content, sample_csv_content_2):
+def sample_data():
     return [
         Data(
             access_url="http://example.com/1",
             title="Test Data 1",
             org="TestOrg",
             mediaType="http://www.iana.org/assignments/media-types/text/csv",
-            content=sample_csv_content,
         ),
         Data(
             access_url="http://example.com/2",
             title="Test Data 2",
             org="TestOrg",
             mediaType="http://www.iana.org/assignments/media-types/text/csv",
-            content=sample_csv_content_2,
         ),
     ]
 
@@ -60,7 +64,7 @@ def test_dataset_as_db_empty_list():
 
 
 def test_dataset_as_db_with_data(sample_data, sample_csv_content):
-    with patch.object(Data, "download", return_value=sample_csv_content):
+    with patch.object(Data, "as_bytes", return_value=sample_csv_content):
         engine = Parser.data_as_db(sample_data)
         assert engine is not None, "Engine should not be None"
 
@@ -80,7 +84,7 @@ def test_dataset_as_vectors():
         Data(access_url="http://example.com/2", title="Test Data 2", org="TestOrg", mediaType="text/plain"),
     ]
 
-    with patch.object(Data, "download", side_effect=["This is a test content.", "Another test content here."]):
+    with patch.object(Data, "as_string", side_effect=["This is a test content.", "Another test content here."]):
         parser.data_as_vectors(data, chunk_size=4)
 
         assert parser.vectors is not None


### PR DESCRIPTION
**Issue**
Currently we download all content as a string and store that string in the Data class. To prepare for additional file types, we should add support for binary downloads, without breaking existing usage. 

**Fix**
Updated the data class
- Added `as_bytes` function, that returns the bytes content
- Added `as_string` function, which returns the string content of the file (as download did before)
- Updated `download` function, it just calls `as_string` and is marked as depreciated, and to be removed in 0.2.0