### PR TITLE
fix: EI-3364 - NyxClient.get_data_for_creators creator not returned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## UNRELEASED
+
+- fix: EI-3331 - Bump iotics-identity to 2.1.2 for security [#15](https://github.com/Iotic-Labs/nyx-sdk/pull/15)
+
+- feat: allow download in bytes [#11](https://github.com/Iotic-Labs/nyx-sdk/pull/11)
+
+- feat: ei-3339 change highlevel example default to openai [#16](https://github.com/Iotic-Labs/nyx-sdk/pull/16)
+
+- fix: EI-3364 - NyxClient.get_data_for_creators creator not returned [#18](https://github.com/Iotic-Labs/nyx-sdk/pull/18)
+
+- fix: EI-3364 - NyxClient.get_subscribed_categories query error
+
+## [0.1.2] - 23/09/2024
+
+- bug: upper casing can break AI when looking for sources [#13](https://github.com/Iotic-Labs/nyx-sdk/pull/13)
+
+## [0.1.1] - 20/09/2024
+
+- fix: override default sample rows; set to 0; plays havoc with getting a defined list of subscriptions [#7](https://github.com/Iotic-Labs/nyx-sdk/pull/7)
+
+- bug: json/excel parsing has invalid param [#7](https://github.com/Iotic-Labs/nyx-sdk/pull/7)
+
 ## [0.1.0] - 19/09/2024
 
 - Initial public release

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## UNRELEASED
+## [0.1.3] - 27/09/2024
 
 - fix: EI-3331 - Bump iotics-identity to 2.1.2 for security [#15](https://github.com/Iotic-Labs/nyx-sdk/pull/15)
 

--- a/nyx_client/client.py
+++ b/nyx_client/client.py
@@ -620,6 +620,13 @@ class NyxClient:
         Returns:
             A list of `Data` instances matching the specified creators.
         """
+        if not creators:
+            return []
+        if len(creators) == 1:
+            # EI-3364 - a single entry results in the query not projecting the creator variable. An additional empty
+            # filter will prevent this whilst not matching anything (since the creator field cannot be empty).
+            creators += [""]
+
         query = f"""
         {_SELECT}
         WHERE {{

--- a/nyx_client/client.py
+++ b/nyx_client/client.py
@@ -265,6 +265,7 @@ class NyxClient:
 
         query = f"""
         PREFIX dcat: <http://www.w3.org/ns/dcat#>
+        PREFIX dct: <http://purl.org/dc/terms/>
 
         SELECT DISTINCT ?theme
         WHERE {{
@@ -285,11 +286,11 @@ class NyxClient:
             A list of genre names.
         """
         query = """
-        PREFIX dc: <http://purl.org/dc/terms/>
+        PREFIX dct: <http://purl.org/dc/terms/>
 
         SELECT DISTINCT ?genre
         WHERE {
-          ?s dc:type ?genre .
+          ?s dct:type ?genre .
         }
         """
 
@@ -304,11 +305,11 @@ class NyxClient:
         if len(self._subscribed_data) == 0:
             return []
         query = f"""
-        PREFIX dc: <http://purl.org/dc/terms/>
+        PREFIX dct: <http://purl.org/dc/terms/>
 
         SELECT DISTINCT ?genre
         WHERE {{
-          ?s dc:type ?genre .
+          ?s dct:type ?genre .
           ?s <{DATA_NAME}> ?name .
           ?s dct:creator ?creator .
           FILTER(?creator != "{self.config.org}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nyx-client"
-version = "0.1.2"
+version = "0.1.3"
 description = "Nyx Client SDK provides a powerful toolkit for building generative AI applications using data brokered on the Nyx platform."
 authors = [
     "Iotics <info@iotics.com>",


### PR DESCRIPTION
- A single entry results in the query not projecting the creator variable.
  An additional empty filter will prevent this whilst not matching anything
  (since the creator field cannot be empty).