### PR TITLE
feat: ei-3457 allow optional file on create/update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.1] - 2024-10-31
+
+### Changed
+- `NyxClient.create_data` and `NyxClient.update_data` now make size and download url optional
+
+### Added
+- `NyxClient.create_data` and `NyxClient.update_data` now support a passing a file to be uploaded
+  either a file, or a download_url must be provided
+
 ## [0.2.0] - 2024-10-18
 
 ### Changed

--- a/nyx_client/README.md
+++ b/nyx_client/README.md
@@ -87,7 +87,9 @@ from nyx_client import NyxClient
 
 client = NyxClient()
 
-with open("somefile.csv") as infile:
+# Open in binary mode with 'b', optionally
+# you can supply and encoding if required
+with open("somefile.csv", 'rb') as infile:
   client.create_data(
       name="MyData1",
       title="My Data #1",

--- a/nyx_client/README.md
+++ b/nyx_client/README.md
@@ -80,6 +80,29 @@ client.create_data(
 )
 ```
 
+### I want to share data using the instance's storage to upload
+
+```python
+from nyx_client import NyxClient
+
+client = NyxClient()
+
+with open("somefile.csv") as infile:
+  client.create_data(
+      name="MyData1",
+      title="My Data #1",
+      description="The description of the data #1",
+      size=1080,
+      genre="ai",
+      categories=["cat1", "cat2", "cat3"],
+      file=infile,
+      content_type="text/csv",
+      lang="fr",
+      preview="col1, col2, col3\naaa, bbb, ccc",
+      license_url="https://opensource.org/licenses/MIT",
+  )
+```
+
 ### I want to delete/disconnect my Data
 
 ```python

--- a/nyx_client/demo.py
+++ b/nyx_client/demo.py
@@ -1,0 +1,18 @@
+from nyx_client import NyxClient
+
+c = NyxClient()
+
+with open("test.csv", "rb") as f:
+    c.create_data(
+        name="MyData4",
+        title="SDK upload test binary",
+        description="SDK file upload test",
+        size=1080,
+        genre="ai",
+        categories=["cat1", "cat2", "cat3"],
+        file=f,
+        content_type="text/csv",
+        lang="fr",
+        preview="col1, col2, col3\naaa, bbb, ccc",
+        license_url="https://opensource.org/licenses/MIT",
+    )

--- a/nyx_client/nyx_client/client.py
+++ b/nyx_client/nyx_client/client.py
@@ -20,7 +20,7 @@ import json
 import logging
 from collections.abc import Sequence
 from enum import Enum, unique
-from io import TextIOBase
+from io import RawIOBase
 from typing import Any, Literal
 from urllib.parse import quote_plus
 
@@ -563,7 +563,7 @@ class NyxClient:
         price: int | None = None,
         license_url: str | None = None,
         download_url: str | None = None,
-        file: TextIOBase | None = None,
+        file: RawIOBase | None = None,
     ) -> Data:
         """Create new data in the system.
 
@@ -576,7 +576,7 @@ class NyxClient:
             genre: The genre or category of the data.
             categories: A list of categories the data belongs to.
             download_url: The URL where the data can be downloaded.
-            file: the file like object (TextIOBase) that you wish to upload
+            file: the file like object (RawIOBase) that you wish to upload
             content_type: The mime type of the data located at download_url.
             lang: The language of the data.
             status: The publication status of the data.
@@ -662,7 +662,7 @@ class NyxClient:
         price: int | None = None,
         license_url: str | None = None,
         download_url: str | None = None,
-        file: TextIOBase | None = None,
+        file: RawIOBase | None = None,
     ) -> Data:
         """Updates existing data in the system.
 
@@ -674,7 +674,7 @@ class NyxClient:
             genre: The genre or category of the data.
             categories: A list of categories the data belongs to.
             download_url: The URL where the data can be downloaded.
-            file: the file like object (TextIOBase) that you wish to upload
+            file: the file like object (RawIOBase) that you wish to upload
             content_type: The mime type of the data located at download_url.
             lang: The language of the data.
             status: The publication status of the data.

--- a/nyx_client/pyproject.toml
+++ b/nyx_client/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nyx-client"
-version = "0.2.0"
+version = "0.2.1"
 description = "Nyx Client offers a simple API for interacting with data in your Nyx network."
 authors = [
     "Iotics <info@iotics.com>",

--- a/nyx_client/test.csv
+++ b/nyx_client/test.csv
@@ -1,0 +1,2 @@
+name,age,role
+bob,44,manager,

--- a/nyx_extras/pyproject.toml
+++ b/nyx_extras/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nyx-extras"
-version = "0.2.0"
+version = "0.2.1"
 description = "Nyx Client SDK Extras provides a powerful toolkit for building generative AI applications using data brokered on the Nyx platform."
 authors = [
     "Iotics <info@iotics.com>",


### PR DESCRIPTION
Update create_data and update_data to make download_url optional, and added an optional file. Can be invoked with the following

```python
with open(filename) as f:
   client.create_data(... file=f)
```

Both methods check that at least one is passed, and also that both aren't provided.