### PR TITLE
fix: download url is incorrect for creating products

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.2] - 2024-11-6
+
+### Fixed
+- `NyxClient.create_data` had a bug where the download url was sent to the API in an incorrect format.
+
 ## [0.2.1] - 2024-10-31
 
 ### Changed

--- a/nyx_client/nyx_client/client.py
+++ b/nyx_client/nyx_client/client.py
@@ -613,7 +613,7 @@ class NyxClient:
             "contentType": content_type,
         }
         if download_url:
-            data["download_url"] = download_url
+            data["downloadURL"] = download_url
             data["size"] = size
 
         if price:

--- a/nyx_client/pyproject.toml
+++ b/nyx_client/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nyx-client"
-version = "0.2.1"
+version = "0.2.2"
 description = "Nyx Client offers a simple API for interacting with data in your Nyx network."
 authors = [
     "Iotics <info@iotics.com>",

--- a/nyx_extras/pyproject.toml
+++ b/nyx_extras/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nyx-extras"
-version = "0.2.1"
+version = "0.2.2"
 description = "Nyx Client SDK Extras provides a powerful toolkit for building generative AI applications using data brokered on the Nyx platform."
 authors = [
     "Iotics <info@iotics.com>",


### PR DESCRIPTION
Creating a product using a URL, instead of a file, will result in a 400 error as "download_url" is not a valid field for the API. 