### PR TITLE
chore(client): Add more top-level imports

### DIFF
--- a/nyx_client/nyx_client/__init__.py
+++ b/nyx_client/nyx_client/__init__.py
@@ -17,7 +17,9 @@
 """NYC client SDK."""
 
 from nyx_client.circles import Circle, RemoteHost
-from nyx_client.client import NyxClient
+from nyx_client.client import NyxClient, SparqlResultType
 from nyx_client.configuration import BaseNyxConfig, ConfigType, NyxConfigExtended
+from nyx_client.connection import Connection
 from nyx_client.data import Data
 from nyx_client.ontology import ALLOW_ALL, ALLOW_NONE
+from nyx_client.property import Property

--- a/nyx_client/nyx_client/client.py
+++ b/nyx_client/nyx_client/client.py
@@ -606,7 +606,7 @@ class NyxClient:
             circles: A list of circles to add share the data with
             custom_metadata: Additional metadata properties to decorate the data with. Note that nyx-internal properties
                 are not allowed.
-            connection_id: the id of a connection to use (id from :class:`.Connection`)
+            connection_id: the id of a connection to use (id from :class:`nyx_client.connection.Connection`)
 
         Returns:
             A `Data` instance, containing the download URL and title.

--- a/nyx_client/nyx_client/data.py
+++ b/nyx_client/nyx_client/data.py
@@ -55,7 +55,7 @@ class Data:
     """Additional metadata properties to decorate the data with. Note that nyx-internal properties are not allowed.
     """
     connection_id: str | None
-    """The ID of the connection (id from :class:`.Connection`)"""
+    """The ID of the connection (id from :class:`nyx_client.connection.Connection`)"""
 
     def __init__(
         self,


### PR DESCRIPTION
Allow e.g.

```python
from nyx_client import SparqlResultType
```

instead of
```python
from nyx_client.client import SparqlResultType
```